### PR TITLE
improve error handling by removing it so I can see what is going wrong

### DIFF
--- a/bin/wgd
+++ b/bin/wgd
@@ -11,7 +11,7 @@ use WGDev::Command;
 our $PACKED;
 our @PACKED;
 
-my $return = eval { WGDev::Command->run(@ARGV) };
+my $return = do { WGDev::Command->run(@ARGV) };
 if ( my $message = $@ ) {
     $message =~ s/\n?\z/\n/msx;
     die $message;

--- a/lib/WGDev/Asset.pm
+++ b/lib/WGDev/Asset.pm
@@ -66,26 +66,13 @@ sub find {
     my $asset;
     my $e;
     if ( $session->id->valid($asset_spec) ) {
-        try {
             $asset = $self->by_id($asset_spec);
-        }
-        catch {
-            $e = $_;
-        };
     }
     if ( !$asset ) {
-        try {
             $asset = WebGUI::Asset->newByUrl( $session, $asset_spec );
-        }
-        catch {
-            $e ||= $_;
-        };
     }
     if ( $asset && ref $asset && $asset->isa('WebGUI::Asset') ) {
         return $asset;
-    }
-    if ($e) {
-        WGDev::X->inflate($e);
     }
     WGDev::X::AssetNotFound->throw( asset => $asset_spec );
 }
@@ -340,7 +327,7 @@ sub _get_property_default {
     if ($form_class) {
         $form_class = "WebGUI::Form::\u$form_class";
         my $form_module = join q{/}, ( split /::/msx, $form_class . '.pm' );
-        if ( eval { require $form_module; 1 } ) {
+        if ( do { require $form_module; 1 } ) {
             my $form = $form_class->new( $self->{session},
                 { defaultValue => $default } );
             $default = $form->getDefaultValue;

--- a/lib/WGDev/Command.pm
+++ b/lib/WGDev/Command.pm
@@ -26,7 +26,7 @@ sub run {
 
     my $command_name = shift @params;
 
-    my $command_module = eval { $class->get_command_module($command_name) };
+    my $command_module = do { $class->get_command_module($command_name) };
     if ( $command_name && !$command_module ) {
         my $command_exec = $class->_find_cmd_exec($command_name);
         if ($command_exec) {
@@ -132,7 +132,7 @@ sub guess_webgui_paths {
     # if that didn't set the root and we have a config, try to set it.
     # if it is absolute, it will give us a root as well
     if ( !$wgd->root && $webgui_config ) {
-        if ( eval { $class->set_config_by_input( $wgd, $webgui_config ); } ) {
+        if ( do { $class->set_config_by_input( $wgd, $webgui_config ); } ) {
             return $wgd
                 if $wgd->root;
         }
@@ -142,7 +142,7 @@ sub guess_webgui_paths {
     }
 
     if ( !$wgd->root ) {
-        if ( !eval { $class->set_root_relative($wgd); 1 } ) {
+        if ( !do { $class->set_root_relative($wgd); 1 } ) {
 
             # throw error from previous try to set the config
             $e->rethrow
@@ -181,14 +181,14 @@ sub set_config_by_input {
     my ( $class, $wgd, $webgui_config ) = @_;
 
     # first, try the specified config file
-    if ( eval { $wgd->config_file($webgui_config) } ) {
+    if ( do { $wgd->config_file($webgui_config) } ) {
         return $wgd;
     }
     my $e = WGDev::X->caught;
 
     # if that didn't work, try it with .conf appended
     if ( $webgui_config !~ /\Q.conf\E$/msx ) {
-        if ( eval { $wgd->config_file( $webgui_config . '.conf' ) } ) {
+        if ( do { $wgd->config_file( $webgui_config . '.conf' ) } ) {
             return $wgd;
         }
     }
@@ -204,7 +204,7 @@ sub set_config_by_sitename {
     my $found_config;
     my $sitename_regex = qr/ (?:^|[.])  \Q$sitename\E $ /msx;
     for my $config_file (@configs) {
-        my $config = eval { Config::JSON->new($config_file) };
+        my $config = do { Config::JSON->new($config_file) };
         next
             if !$config;
         for my $config_sitename ( @{ $config->get('sitename') } ) {
@@ -260,7 +260,7 @@ sub get_command_module {
     if ( $command_name && $command_name =~ /^\w+(?:-\w+)*$/mxs ) {
         my $module = $class->command_to_module($command_name);
         ( my $module_file = "$module.pm" ) =~ s{::}{/}mxsg;
-        if (   eval { require $module_file; 1 }
+        if (   do { require $module_file; 1 }
             && $module->can('run')
             && $module->can('is_runnable')
             && $module->is_runnable )
@@ -331,7 +331,7 @@ sub command_list {
         $package =~ s/\Q.pm\E$//msx;
         $package = join q{::}, File::Spec->splitdir($package);
         ##no critic (RequireCheckingReturnValueOfEval)
-        eval {
+        do {
             require $module;
             if ( $package->can('run')
                 && $package->can('is_runnable')

--- a/lib/WGDev/Command/Batchedit.pm
+++ b/lib/WGDev/Command/Batchedit.pm
@@ -58,7 +58,7 @@ sub process {
         my $asset;
         my $parent;
         if ( $asset_data->{parent} ) {
-            $parent = eval { $wgd->asset->find( $asset_data->{parent} ) };
+            $parent = do { $wgd->asset->find( $asset_data->{parent} ) };
         }
         if ( $asset_to_edit->{asset_id} ) {
             $asset = $wgd->asset->by_id( $asset_to_edit->{asset_id}, undef,
@@ -101,7 +101,7 @@ sub get_assets_data {
     my $wgd  = $self->wgd;
     my @assets_data;
     for my $asset_spec ( $self->arguments ) {
-        my $asset_data = eval { $self->get_asset_data($asset_spec) };
+        my $asset_data = do { $self->get_asset_data($asset_spec) };
         if ( !$asset_data ) {
             warn $@;
             next;
@@ -143,7 +143,7 @@ sub get_asset_data {
 
     my $wgd_asset = $self->wgd->asset;
     if ( !ref $asset ) {
-        $asset = eval { $wgd_asset->find($asset) };
+        $asset = do { $wgd_asset->find($asset) };
         if ( !$asset ) {
             die $@;
         }

--- a/lib/WGDev/Command/Commands.pm
+++ b/lib/WGDev/Command/Commands.pm
@@ -50,7 +50,7 @@ sub command_abstracts {
     $parser->select('NAME');
     for my $command ( keys %abstracts ) {
         my $command_module
-            = eval { WGDev::Command->get_command_module($command) };
+            = do { WGDev::Command->get_command_module($command) };
         next
             if !$command_module;
         my $pod           = WGDev::Help::package_pod($command_module);

--- a/lib/WGDev/Command/Config.pm
+++ b/lib/WGDev/Command/Config.pm
@@ -55,7 +55,7 @@ sub process {
         if ( $self->option('struct') ) {
             $value =~ s/\A \s* ( [[{] ) /--- $1/msx;
             $value .= "\n";
-            eval {
+            do {
                 $value = WGDev::yaml_decode($value);
                 1;
             } or WGDev::X->throw('Invalid or unsupported format.');

--- a/lib/WGDev/Command/Edit.pm
+++ b/lib/WGDev/Command/Edit.pm
@@ -54,7 +54,7 @@ sub process {
         my $asset;
         my $parent;
         if ( $asset_data->{parent} ) {
-            $parent = eval { $wgd->asset->find( $asset_data->{parent} ) };
+            $parent = do { $wgd->asset->find( $asset_data->{parent} ) };
         }
         if ( $file->{asset_id} ) {
             $asset = $wgd->asset->by_id( $file->{asset_id}, undef,
@@ -97,7 +97,7 @@ sub export_asset_data {
     my $wgd  = $self->wgd;
     my @files;
     for my $asset_spec ( $self->arguments ) {
-        my $file_data = eval { $self->write_temp($asset_spec) };
+        my $file_data = do { $self->write_temp($asset_spec) };
         if ( !$file_data ) {
             warn $@;
             next;
@@ -139,8 +139,8 @@ sub write_temp {
 
     my $wgd_asset = $self->wgd->asset;
     if ( !ref $asset ) {
-        $asset = eval { $wgd_asset->find($asset) }
-            || eval { scalar $wgd_asset->validate_class($asset) };
+        $asset = do { $wgd_asset->find($asset) }
+            || do { scalar $wgd_asset->validate_class($asset) };
         if ( !$asset ) {
             die $@;
         }

--- a/lib/WGDev/Command/Export.pm
+++ b/lib/WGDev/Command/Export.pm
@@ -19,8 +19,8 @@ sub process {
 
     my $wgd_asset = $self->wgd->asset;
     for my $asset_spec ( $self->arguments ) {
-        my $asset = eval { $wgd_asset->find($asset_spec) }
-            || eval { $wgd_asset->validate_class($asset_spec) };
+        my $asset = do { $wgd_asset->find($asset_spec) }
+            || do { $wgd_asset->validate_class($asset_spec) };
         if ( !$asset ) {
             warn $@;
             next;

--- a/lib/WGDev/Command/Export/Branch.pm
+++ b/lib/WGDev/Command/Export/Branch.pm
@@ -35,7 +35,7 @@ sub process {
     my $heir = $self->option('hier');
 
     for my $asset_spec ( $self->arguments ) {
-        my $base_asset = eval { $wgd_asset->find($asset_spec) };
+        my $base_asset = do { $wgd_asset->find($asset_spec) };
         if ( !$base_asset ) {
             warn $@;
             next;

--- a/lib/WGDev/Command/For/Each.pm
+++ b/lib/WGDev/Command/For/Each.pm
@@ -112,14 +112,14 @@ sub process {
 
     my $root = $self->wgd->root;
     SITES: for my $config ( $self->wgd->list_site_configs ) {
-        my $wgd = eval { WGDev->new( $root, $config ) };
+        my $wgd = do { WGDev->new( $root, $config ) };
         if ( $wgd ) {
             ##no critic (ProhibitCStyleForLoops ProhibitLocalVars)
             local $self->{wgd} = $wgd;
             COMMANDS: for (my $i = 0; $i <= $#commands; $i += 2) {
                 my $command = $commands[$i];
                 my @params = @{ $commands[$i + 1] };
-                my $success = eval {
+                my $success = do {
                     $self->$command(@params) || 1;
                 };
                 if ( $success ) {

--- a/lib/WGDev/Command/Import.pm
+++ b/lib/WGDev/Command/Import.pm
@@ -24,12 +24,12 @@ sub process {
         my $asset_data = $wgd_asset->deserialize($asset_text);
         my $parent;
         if ( $asset_data->{parent} ) {
-            $parent = eval { $wgd_asset->find( $asset_data->{parent} ) };
+            $parent = do { $wgd_asset->find( $asset_data->{parent} ) };
         }
         my $asset;
         my $mode;
 
-        if ( eval { $asset = $wgd_asset->by_id( $asset_data->{assetId} ) } ) {
+        if ( do { $asset = $wgd_asset->by_id( $asset_data->{assetId} ) } ) {
             $mode = 'Updating';
             $asset->addRevision( $asset_data, undef,
                 { skipAutoCommitWorkflows => 1, skipNotification => 1 } );

--- a/lib/WGDev/Command/Ls.pm
+++ b/lib/WGDev/Command/Ls.pm
@@ -32,7 +32,7 @@ sub option_filter {
         WGDev::X->throw("Invalid filter specified: $filter");
     }
     if ( $filter_match =~ m{\A/(.*)/\Z}msx ) {
-        eval { $filter_match = qr/$1/msx; }
+        do { $filter_match = qr/$1/msx; }
             || WGDev::X->throw(
             "Specified filter is not a valid regular expression: $1");
     }
@@ -69,7 +69,7 @@ sub process {
     PARENT:
     while ( my $parent = shift @parents ) {
         my $asset;
-        if ( !eval { $asset = $wgd->asset->find($parent) } ) {
+        if ( !do { $asset = $wgd->asset->find($parent) } ) {
             warn "wgd ls: $parent: No such asset\n";
             $error++;
             next;

--- a/lib/WGDev/Command/Package.pm
+++ b/lib/WGDev/Command/Package.pm
@@ -50,7 +50,7 @@ sub process {
             );
         }
         for my $asset_spec ( $self->arguments ) {
-            my $asset = eval { $wgd->asset->find($asset_spec) } || do {
+            my $asset = do { $wgd->asset->find($asset_spec) } || do {
                 warn "Unable to find asset $asset_spec!\n";
                 next;
             };
@@ -67,7 +67,7 @@ sub process {
     if ( $self->option('import') ) {
         my $parent
             = $self->option('parent')
-            ? eval { $wgd->asset->find( $self->option('parent') ) }
+            ? do { $wgd->asset->find( $self->option('parent') ) }
             : $wgd->asset->import_node;
         if ( !$parent ) {
             warn "Unable to find parent node!\n";
@@ -93,7 +93,7 @@ sub process {
                     message => $asset,
                 );
             }
-            elsif ( ! eval { $asset->isa('WebGUI::Asset') } ) {
+            elsif ( ! do { $asset->isa('WebGUI::Asset') } ) {
                 # not an asset or an error?  this shouldn't ever happen.
                 WGDev::X::BadPackage->throw(
                     package => $package,

--- a/lib/WGDev/Command/Reset.pm
+++ b/lib/WGDev/Command/Reset.pm
@@ -526,7 +526,7 @@ END_SQL
         if ( !defined $current_revision || $current_revision == $revision ) {
             next;
         }
-        my $asset = eval { $wgd->asset->by_id($id, $revision) };
+        my $asset = do { $wgd->asset->by_id($id, $revision) };
         next
             unless $asset;
 
@@ -684,10 +684,10 @@ sub autologon {
     my @session_ids;
     $self->report('Getting active browser site sessions... ');
     my $success;
-    if ( eval { push @session_ids, $self->get_firefox_sessions; 1 } ) {
+    if ( do { push @session_ids, $self->get_firefox_sessions; 1 } ) {
         $success = 1;
     }
-    if ( eval { push @session_ids, $self->get_safari_sessions; 1 } ) {
+    if ( do { push @session_ids, $self->get_safari_sessions; 1 } ) {
         $success = 1;
     }
     if ($success) {
@@ -724,7 +724,7 @@ sub get_firefox_sessions {
             PrintError => 0,
             RaiseError => 1,
             ##no critic (ProhibitMagicNumbers)
-            eval { DBD::SQLite->VERSION(1.27) }
+            do { DBD::SQLite->VERSION(1.27) }
             ? ( sqlite_unicode => 1 )
             : ( unicode => 1 ),
         } );

--- a/lib/WGDev/Command/Trash.pm
+++ b/lib/WGDev/Command/Trash.pm
@@ -39,7 +39,7 @@ sub trash {
     ASSET:
     while ( my $asset_spec = shift @asset_specs ) {
         my $asset;
-        if ( !eval { $asset = $wgd->asset->find($asset_spec) } ) {
+        if ( !do { $asset = $wgd->asset->find($asset_spec) } ) {
             warn "wgd trash: $asset_spec: No such asset\n";
             $error++;
             next ASSET;

--- a/lib/WGDev/Command/Version.pm
+++ b/lib/WGDev/Command/Version.pm
@@ -47,7 +47,7 @@ sub process {
     my $db_version = $wgv->database_script;
     my ( $change_file, $change_version ) = $wgv->changelog;
     my ( $up_file, undef, $up_file_ver, $up_version ) = $wgv->upgrade;
-    my $db_live_version = eval { $wgv->database( $wgd->db->connect ) };
+    my $db_live_version = do { $wgv->database( $wgd->db->connect ) };
 
     my $err_count = 0;
     my $expect_ver = $ver || $perl_version;
@@ -159,7 +159,7 @@ sub update_version {
 
 sub _colored {
     no warnings 'redefine';
-    if ( eval { require Term::ANSIColor; 1 } ) {
+    if ( do { require Term::ANSIColor; 1 } ) {
         *_colored = \&Term::ANSIColor::colored;
     }
     else {

--- a/lib/WGDev/X.pm
+++ b/lib/WGDev/X.pm
@@ -90,22 +90,6 @@ BEGIN {
     if ( $ENV{WGDEV_DEBUG} ) {
         WGDev::X->Trace(1);
     }
-    ##no critic (ProhibitMagicNumbers)
-    if ( !eval { Exception::Class->VERSION(1.27) } ) {
-
-        # work around bad behavior of Exception::Class < 1.27
-        # where it defaults the message to $!
-        no warnings 'once';
-        *WGDev::X::new = sub {
-            my $errno = qq{$!};
-            my $class = shift;
-            my $self  = $class->SUPER::new(@_);
-            if ( $self->{message} eq $errno ) {
-                $self->{message} = q{};
-            }
-            return $self;
-        };
-    }
 }
 
 ##no critic (ProhibitQualifiedSubDeclarations)

--- a/t/00_load.t
+++ b/t/00_load.t
@@ -17,7 +17,7 @@ foreach my $library (@modules) {
     local $SIG{__WARN__} = sub {
         $warnings .= shift;
     };
-    eval { require $library; };
+    do { require $library; };
     chomp $warnings;
     is( $@,        '', "$library compiles successfully" );
     is( $warnings, '', "$library compiles without warnings" );


### PR DESCRIPTION
since you can't play with them responsibly, remove all uses of eval { and try { (okay, almost all try { ) =P

that way I can actually see the error message "Open of share file /tmp/WebGUICache/bleahbleahbleah.conf.dat failed: Permission denied at /data/wre/prereqs/lib/perl5/site_perl/5.10.0/i686-linux/Cache/FastMmap.pm line 629." instead of some useless nonsense about a bad class.
